### PR TITLE
Turbo colormap

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can use local source for torch hub to load the ZoeDepth models, for example:
 import torch
 
 # Zoe_N
-model_zoe_n = torch.hub.load(".", "ZoeD_N", source="local" pretrained=True)
+model_zoe_n = torch.hub.load(".", "ZoeD_N", source="local", pretrained=True)
 ```
 
 #### or load the models manually
@@ -125,7 +125,8 @@ save_raw_16bit(depth, fpath)
 # Colorize output
 from zoedepth.utils.misc import colorize
 
-colored = colorize(depth)
+# Use cmap="magma_r" for a linear color map, cmap="turbo_r" for a high contrast disparity color map
+colored = colorize(depth, cmap="magma_r")
 
 # save colored output
 fpath_colored = "/path/to/output_colored.png"

--- a/zoedepth/utils/misc.py
+++ b/zoedepth/utils/misc.py
@@ -94,14 +94,14 @@ class RunningAverageDict:
         return {key: value.get_value() for key, value in self._dict.items()}
 
 
-def colorize(value, vmin=None, vmax=None, cmap='gray_r', invalid_val=-99, invalid_mask=None, background_color=(128, 128, 128, 255), gamma_corrected=False, value_transform=None):
+def colorize(value, vmin=None, vmax=None, cmap='turbo_r', invalid_val=-99, invalid_mask=None, background_color=(128, 128, 128, 255), gamma_corrected=False, value_transform=None):
     """Converts a depth map to a color image.
 
     Args:
         value (torch.Tensor, numpy.ndarry): Input depth map. Shape: (H, W) or (1, H, W) or (1, 1, H, W). All singular dimensions are squeezed
         vmin (float, optional): vmin-valued entries are mapped to start color of cmap. If None, value.min() is used. Defaults to None.
         vmax (float, optional):  vmax-valued entries are mapped to end color of cmap. If None, value.max() is used. Defaults to None.
-        cmap (str, optional): matplotlib colormap to use. Defaults to 'magma_r'.
+        cmap (str, optional): matplotlib colormap to use. Defaults to 'turbo_r'.
         invalid_val (int, optional): Specifies value of invalid pixels that should be colored as 'background_color'. Defaults to -99.
         invalid_mask (numpy.ndarray, optional): Boolean mask for invalid regions. Defaults to None.
         background_color (tuple[int], optional): 4-tuple RGB color to give to invalid pixels. Defaults to (128, 128, 128, 255).
@@ -358,7 +358,7 @@ def pil_to_batched_tensor(img):
 def save_raw_16bit(depth, fpath="raw.png"):
     if isinstance(depth, torch.Tensor):
         depth = depth.squeeze().cpu().numpy()
-    
+
     assert isinstance(depth, np.ndarray), "Depth must be a torch tensor or numpy array"
     assert depth.ndim == 2, "Depth must be 2D"
     depth = depth * 256  # scale for 16-bit png


### PR DESCRIPTION
Hi, first thanks for this nice paper!

For plotting in this repo, what would you think of using a different [colormap designed for depth](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html)?
It make it much easier to see details, compare distant points in the image, and is friendlier to color blindness. Also it has already been [added to matplotlib a while back](https://matplotlib.org/3.3.0/users/whats_new.html#turbo-colormap) so is widely available. Subjectively I think it also highlight the quality of your work!
(it's only a detail I know, but a bit of a pet peeve of mine 😅)

![example_turbo_1](https://user-images.githubusercontent.com/3440771/222647473-2111a6a4-fc0e-4803-a8b9-87f6c7c6e47b.png)

<details>
<summary>More sample images</summary>

![example_turbo_2](https://user-images.githubusercontent.com/3440771/222647494-cc44c805-f7a5-4933-bdeb-166838617c4a.png)

![example_turbo_3](https://user-images.githubusercontent.com/3440771/222647501-710e33df-0f53-4543-ad03-e58b366d609b.png)

![example_turbo_4](https://user-images.githubusercontent.com/3440771/222648665-5435a59d-b36c-4128-9a82-fae5abe1495c.png)

![example_turbo_5](https://user-images.githubusercontent.com/3440771/222648671-bc7df2f6-737c-4a9f-89c9-41c2bc38216f.png)

</details>