### PR TITLE
Change for compatibility with NumPy 1.24

### DIFF
--- a/zoedepth/data/transforms.py
+++ b/zoedepth/data/transforms.py
@@ -372,7 +372,7 @@ class Rescale(object):
         if self.__use_mask:
             mask = sample["mask"]
         else:
-            mask = np.ones_like(disp, dtype=np.bool)
+            mask = np.ones_like(disp, dtype=bool)
 
         if np.sum(mask) == 0:
             return sample


### PR DESCRIPTION
`np.bool` deprecation expired in NumPy 1.24 (that is, it was removed).

I don't know whether this change actually fixes some issue, but IMHO it seems proper to do it regardless.