### PR TITLE
Compatibility with Torch > 2.0.1

### DIFF
--- a/zoedepth/models/base_models/midas.py
+++ b/zoedepth/models/base_models/midas.py
@@ -170,6 +170,8 @@ class Resize(object):
 
     def __call__(self, x):
         width, height = self.get_size(*x.shape[-2:][::-1])
+        height = int(height)
+        width = int(width)
         return nn.functional.interpolate(x, (height, width), mode='bilinear', align_corners=True)
 
 class PrepForMidas(object):


### PR DESCRIPTION
Hello @shariqfarooq123 

We're working with the [latest nightly version](https://download.pytorch.org/whl/nightly/torch/) of torch. They seem to have added type asserts to interpolate [(this commit)](https://github.com/pytorch/pytorch/commit/6bda97e2c16fb35f743ff3fe292782d7ee082877). 

This causes a runtime error because the size we pass in is of type `numpy.int32`. A simple int-cast should fix this without any side effects.