### PR TITLE
update zoedepth to be compatible with torch 2.1

### DIFF
--- a/zoedepth/models/base_models/midas.py
+++ b/zoedepth/models/base_models/midas.py
@@ -170,7 +170,7 @@ class Resize(object):
 
     def __call__(self, x):
         width, height = self.get_size(*x.shape[-2:][::-1])
-        return nn.functional.interpolate(x, (height, width), mode='bilinear', align_corners=True)
+        return nn.functional.interpolate(x, (int(height), int(width)), mode='bilinear', align_corners=True)
 
 class PrepForMidas(object):
     def __init__(self, resize_mode="minimal", keep_aspect_ratio=True, img_size=384, do_resize=True):


### PR DESCRIPTION
In the upcoming torch 2.1 release, `torch.nn.functional.interpolate` expect size type signature to be Tuple[int], Tuple[int, int] or Tuple[int, int, int]. 
Currently width and height in this function are passed as np.int64. This PR fixes that